### PR TITLE
Fix chrome in floating mode

### DIFF
--- a/core/java/android/content/Intent.java
+++ b/core/java/android/content/Intent.java
@@ -3788,15 +3788,7 @@ public class Intent implements Parcelable, Cloneable {
      * in multi window scenarios.
      * @hide
      */
-    public static final int FLAG_FLOATING_WINDOW = 0x00002000;
-    /**
-     * If set in an Intent passed to {@link Context#startActivity Context.startActivity()},
-     * this flag will cause a newly launching task to be resized according to the split
-     * view metrics, making it running alongside another app.
-     * @hide
-     */
-    public static final int FLAG_ACTIVITY_SPLIT_VIEW = 0x00001000;
-
+    public static final int FLAG_FLOATING_WINDOW = 0X80000000;
     /**
      * If set, when sending a broadcast only registered receivers will be
      * called -- no BroadcastReceiver components will be launched.


### PR DESCRIPTION
This fixes chrome forcefully opening in windowed mode, the same flag (in hex) must be being used in chrome for something else.
The flag which is removed in the commit was never referenced in code so get it out of the way.
