### PR TITLE
Fix Msim status bar FC

### DIFF
--- a/packages/SystemUI/res/layout/msim_status_bar.xml
+++ b/packages/SystemUI/res/layout/msim_status_bar.xml
@@ -85,6 +85,15 @@
                     />
 
                 </com.android.keyguard.AlphaOptimizedLinearLayout>
+                
+                <com.android.systemui.statusbar.widget.CarrierLabel
+                    android:id="@+id/status_bar_carrier_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:textAppearance="@style/TextAppearance.StatusBar.Clock"
+                    android:singleLine="true"
+                    android:ellipsize="end"/>
 
                 <com.android.systemui.statusbar.StatusBarIconView android:id="@+id/moreIcon"
                     android:layout_width="@dimen/status_bar_icon_size"
@@ -106,6 +115,14 @@
             android:layout_height="match_parent"
             android:orientation="horizontal"
             >
+    
+        <com.android.systemui.statusbar.policy.NetworkTraffic
+            android:id="@+id/networkTraffic"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:singleLine="false"
+            android:fontFamily="sans-serif-condensed"
+            android:gravity="right|center_vertical"/>
 
             <include layout="@layout/msim_system_icons" />
 
@@ -156,4 +173,9 @@
         android:layout_height="match_parent"
         />
 
-</com.android.systemui.statusbar.phone.PhoneStatusBarView>
+    <com.android.systemui.statusbar.policy.BatteryBarController
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        systemui:viewLocation="1" />
+
+    </com.android.systemui.statusbar.phone.PhoneStatusBarView>


### PR DESCRIPTION
Settings commit will follow shortly to remove the carrier label option on Msim too.
safe to merge this one now though.