### PR TITLE
SystemUI: Keyguard: Divide mA on plugged USB

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/KeyguardIndicationController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/KeyguardIndicationController.java
@@ -70,6 +70,7 @@ public class KeyguardIndicationController {
     private boolean mVisible;
 
     private boolean mPowerPluggedIn;
+    private boolean mUSBPluggedIn;
     private boolean mPowerCharged;
     private int mChargingSpeed;
     private int mChargingCurrent;
@@ -179,7 +180,7 @@ public class KeyguardIndicationController {
         if (mPowerPluggedIn) {
             String indication = computePowerIndication();
             if (DEBUG_CHARGING_CURRENT) {
-                indication += ",  " + mChargingCurrent + " mA";
+                indication += ",  " + (mUSBPluggedIn ? mChargingCurrent/1000 : mChargingCurrent) + " mA";
             }
             return indication;
         }
@@ -235,6 +236,7 @@ public class KeyguardIndicationController {
             boolean isChargingOrFull = status.status == BatteryManager.BATTERY_STATUS_CHARGING
                     || status.status == BatteryManager.BATTERY_STATUS_FULL;
             mPowerPluggedIn = status.isPluggedIn() && isChargingOrFull;
+            mUSBPluggedIn = (status.plugged == BatteryManager.BATTERY_PLUGGED_USB);
             mPowerCharged = status.isCharged();
             mChargingCurrent = status.maxChargingCurrent;
             mChargingSpeed = status.getChargingSpeed((mSlowThreshold / 1000), (mFastThreshold / 1000));


### PR DESCRIPTION
When USB cable is connected (not charger) Keyguard shows too high mA value (500000 mA instead of 500 mA) :smile: On AC everything is OK..
